### PR TITLE
Correct teamwork.com favicon url

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Formerly started at [<img src="https://ycombinator.com/favicon.ico" alt="YCombin
 ### Project Management
 [<img src="https://tree.taiga.io/images/favicon.png" alt="Taiga.io" height="16" /> Taiga.io](https://taiga.io) - Agile project management platform - free for public projects
 
-[<img src="https://www.teamwork.com/favicon.ico" alt="Teamwork" height="16" /> Teamwork](https://www.teamwork.com/) - free for 2 Projects, 10MB Storage
+[<img src="https://www.teamwork.com/images/favicon/favicon.ico" alt="Teamwork" height="16" /> Teamwork](https://www.teamwork.com/) - free for 2 Projects, 10MB Storage
 
 [<img src="https://trello.com/favicon.ico" alt="Trello" height="16" /> Trello](https://trello.com/) - simple bugtracker - free for all
 


### PR DESCRIPTION
Currently 404ing, looks like they moved it